### PR TITLE
Add wakeup function for ROCK 4C+

### DIFF
--- a/u-boot/latest/0021-rock-4c-plus/0001-arm-dts-rockchip-add-support-for-Radxa-ROCK-4C.patch
+++ b/u-boot/latest/0021-rock-4c-plus/0001-arm-dts-rockchip-add-support-for-Radxa-ROCK-4C.patch
@@ -9,10 +9,10 @@ Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
  arch/arm/dts/Makefile                        |   1 +
  arch/arm/dts/rk3399-rock-4c-plus-u-boot.dtsi |   6 +
- arch/arm/dts/rk3399-rock-4c-plus.dts         | 733 +++++++++++++++++++
+ arch/arm/dts/rk3399-rock-4c-plus.dts         | 734 +++++++++++++++++++
  arch/arm/dts/rk3399-t-opp.dtsi               | 114 +++
  configs/rock-4c-plus-rk3399_defconfig        |  87 +++
- 5 files changed, 941 insertions(+)
+ 5 files changed, 942 insertions(+)
  create mode 100644 arch/arm/dts/rk3399-rock-4c-plus-u-boot.dtsi
  create mode 100644 arch/arm/dts/rk3399-rock-4c-plus.dts
  create mode 100644 arch/arm/dts/rk3399-t-opp.dtsi
@@ -44,10 +44,10 @@ index 00000000..b7dcd2e0
 +#include "rk3399-rock-pi-4-u-boot.dtsi"
 diff --git a/arch/arm/dts/rk3399-rock-4c-plus.dts b/arch/arm/dts/rk3399-rock-4c-plus.dts
 new file mode 100644
-index 00000000..70759e94
+index 00000000..280b9cf3
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-rock-4c-plus.dts
-@@ -0,0 +1,733 @@
+@@ -0,0 +1,734 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
@@ -265,6 +265,7 @@ index 00000000..70759e94
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&pmic_int_l>;
 +		rockchip,system-power-controller;
++		pmic-reset-func = <0>;
 +		wakeup-source;
 +
 +		vcc1-supply = <&vcc5v0_sys>;
@@ -995,5 +996,5 @@ index 00000000..f864c732
 +CONFIG_ERRNO_STR=y
 +CONFIG_OF_LIBFDT_OVERLAY=y
 -- 
-2.38.1
+2.25.1
 


### PR DESCRIPTION
Fix cannot wakeup by pressing powerkey when shutdown

Signed-off-by: Ken <ken@radxa.com>