### PR TITLE
linux: common: enable BLK_DEV_NBD=m

### DIFF
--- a/linux/.common/kconfig.conf
+++ b/linux/.common/kconfig.conf
@@ -745,3 +745,8 @@ CONFIG_CAN_MCP251X=m
 
 ## Enable USB printer driver
 CONFIG_USB_PRINTER=m
+
+## Enable NBD support
+## Ceph rbd-nbd https://github.com/rockchip-linux/kernel/issues/303
+## https://github.com/radxa/kernel/issues/139
+CONFIG_BLK_DEV_NBD=m


### PR DESCRIPTION
close https://github.com/radxa/kernel/issues/139
https://github.com/rockchip-linux/kernel/issues/303

log :
W0706 08:05:02.918278   40415 rbd_attach.go:209] rbd-nbd: nbd modprobe failed with error an error (exit status 1) occurred while running modprobe args: [nbd]
E0706 08:05:03.002118   40415 rbd_util.go:241] modprobe failed: an error (exit status 1) occurred while running modprobe args: [rbd]
F0706 08:05:03.002490   40415 driver.go:148] an error (exit status 1) occurred while running modprobe args: [rbd]