### PR TITLE
linux: rock-pi-e : fix PMIC_INT pinctrl, Ethernet port indicator, spidev0.0 issue

### DIFF
--- a/linux/stable/0034-rock-pi-e/0001-Change-the-PMIC_INT-pinctrl.patch
+++ b/linux/stable/0034-rock-pi-e/0001-Change-the-PMIC_INT-pinctrl.patch
@@ -1,0 +1,26 @@
+From 9003285ce163f6bfe708bffd77168be22cfd8f3a Mon Sep 17 00:00:00 2001
+From: machuang <machuang@radxa.com>
+Date: Tue, 10 Oct 2023 17:09:22 +0800
+Subject: [PATCH 1/3] Change the PMIC_INT pinctrl
+
+Signed-off-by: machuang <machuang@radxa.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+index 018a3a507..3f962cf8f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+@@ -332,7 +332,7 @@ led_pin: led-pin {
+ 
+ 	pmic {
+ 		pmic_int_l: pmic-int-l {
+-			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+-- 
+2.25.1
+

--- a/linux/stable/0034-rock-pi-e/0002-Example-Repair-Ethernet-port-indicators.patch
+++ b/linux/stable/0034-rock-pi-e/0002-Example-Repair-Ethernet-port-indicators.patch
@@ -1,0 +1,94 @@
+From 83b2eb40d60e68b11da8b66922d60cefd92a76b1 Mon Sep 17 00:00:00 2001
+From: machuang <machuang@radxa.com>
+Date: Tue, 10 Oct 2023 17:11:40 +0800
+Subject: [PATCH 2/3] Example Repair Ethernet port indicators
+
+Signed-off-by: machuang <machuang@radxa.com>
+---
+ .../net/ethernet/stmicro/stmmac/stmmac_main.c | 56 +++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+index 693197302..65b4dbdff 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -60,6 +60,12 @@
+ #define	STMMAC_ALIGN(x)		ALIGN(ALIGN(x, SMP_CACHE_BYTES), 16)
+ #define	TSO_MAX_BUFF_SIZE	(SZ_16K - 1)
+ 
++#define RTL8211F_PHY_UID        0x001cc800
++#define RTL8211F_PHY_UID_MASK   0x001ffc00
++#define RTL8211F_PAGE_SELECT    0x1f
++#define RTL8211F_LCR_ADDR       0x10
++#define RTL8211F_EEELCR_ADDR    0x11
++
+ /* Module parameters */
+ #define TX_TIMEO	5000
+ static int watchdog = TX_TIMEO;
+@@ -7039,6 +7045,44 @@ int stmmac_reinit_ringparam(struct net_device *dev, u32 rx_size, u32 tx_size)
+ 	return ret;
+ }
+ 
++static int phy_rtl8211f_led_fixup(struct phy_device *phydev)
++{
++	u32 val, val2;
++	/* Switch to Page 0x0d04 */
++	phy_write(phydev, RTL8211F_PAGE_SELECT, 0x0d04);
++	/* Set LED1(Green) Link 10/100/1000M + Active, and set LED2(Yellow) Link 10/100/1000M */
++	val = phy_read(phydev, RTL8211F_LCR_ADDR);
++	val |= (1<<5);
++	val |= (1<<8);
++	val |= (1<<10);
++	val |= (1<<11);
++	val &= (~(1<<14));
++	phy_write(phydev, RTL8211F_LCR_ADDR, val);
++	/* Disable LED2(Yellow) EEE LED function to keep it on when linked */
++	val2 = phy_read(phydev, RTL8211F_EEELCR_ADDR);
++	val2 &= (~(1<<3));
++	phy_write(phydev, RTL8211F_EEELCR_ADDR, val2);
++	/* Switch back to the PHY's IEEE Standard Registers. Here it is Page 0 */
++	phy_write(phydev, RTL8211F_PAGE_SELECT, 0);
++	return 0;
++}
++
++static int phy_rtl8211f_eee_fixup(struct phy_device *phydev)
++{
++	phy_write(phydev, 31, 0x0000);
++	phy_write(phydev,  0, 0x8000);
++	mdelay(20);
++	phy_write(phydev, 31, 0x0a4b);
++	phy_write(phydev, 17, 0x1110);
++	phy_write(phydev, 31, 0x0000);
++	phy_write(phydev, 13, 0x0007);
++	phy_write(phydev, 14, 0x003c);
++	phy_write(phydev, 13, 0x4007);
++	phy_write(phydev, 14, 0x0000);
++
++	return 0;
++}
++
+ #define SEND_VERIFY_MPAKCET_FMT "Send Verify mPacket lo_state=%d lp_state=%d\n"
+ static void stmmac_fpe_lp_task(struct work_struct *work)
+ {
+@@ -7418,6 +7462,18 @@ int stmmac_dvr_probe(struct device *device,
+ 	if (priv->plat->dump_debug_regs)
+ 		priv->plat->dump_debug_regs(priv->plat->bsp_priv);
+ 
++	/* Register fixup for PHY RTL8211F */
++	ret = phy_register_fixup_for_uid(RTL8211F_PHY_UID, RTL8211F_PHY_UID_MASK, phy_rtl8211f_led_fixup);
++	if (ret) {
++		dev_warn(priv->device, "Failed to register fixup for PHY RTL8211F.\n");
++	}
++
++	/* Register fixup for PHY RTL8211F disabling EEE */
++	ret = phy_register_fixup_for_uid(RTL8211F_PHY_UID, RTL8211F_PHY_UID_MASK, phy_rtl8211f_eee_fixup);
++	if (ret) {
++		dev_warn(priv->device, "Failed to register fixup for PHY RTL8211F disabling EEE.\n");
++	}
++
+ 	/* Let pm_runtime_put() disable the clocks.
+ 	 * If CONFIG_PM is not enabled, the clocks will stay powered.
+ 	 */
+-- 
+2.25.1
+


### PR DESCRIPTION
Rock pi e switched to the latest kernel in bsp

0001: Fixed the rk805 PMIC INT GPIO pin definition error

0002: Fixed The 1000M Ethernet port indicator is faulty

0003: Add compatible attribute to kernel spidev driver to solve spidev driver does not match spi0