### PR TITLE
linux: enable CONFIG_SENSORS_DRIVETEMP and CONFIG_TASK_DELAY_ACCT

### DIFF
--- a/linux/.common/kconfig.conf
+++ b/linux/.common/kconfig.conf
@@ -870,3 +870,10 @@ CONFIG_FSCACHE=m
 # Enable Ceph Filesystem
 # radxa-build/rock-5-itx#3
 CONFIG_CEPH_FS=m
+
+#drivetemp reports SATA/SAS temperature (and e.g. sensors utility of lm-sensors package can reports values). See https://docs.kernel.org/hwmon/drivetemp.html
+CONFIG_SENSORS_DRIVETEMP=m
+
+#enables some utilities (e.g. iotop, iotop-c) to gather more detailed statistics. One still needs to enable this feature in runtime. CONFIG_TASK_DELAY_ACCT requires CONFIG_TASKSTATS, so it was added explicitly. See https://docs.kernel.org/accounting/delay-accounting.html
+CONFIG_TASK_DELAY_ACCT=y
+CONFIG_TASKSTATS=y


### PR DESCRIPTION
Hello.
CONFIG_SENSORS_DRIVETEMP=m will build a module named drivetemp.ko. Which will in turn export e.g. hdd temp when loaded:

<details>

<summary>sensors(comes in lm-sensors package) output with drivetemp.ko loaded, note the drivetemp-scsi-0-0</summary>

```bash
root@rock-5-itx:/home/rock# sensors
npu_thermal-virtual-0
Adapter: Virtual device
temp1:        +24.1°C  (crit = +115.0°C)

center_thermal-virtual-0
Adapter: Virtual device
temp1:        +23.1°C  (crit = +115.0°C)

bigcore1_thermal-virtual-0
Adapter: Virtual device
temp1:        +24.1°C  (crit = +115.0°C)

soc_thermal-virtual-0
Adapter: Virtual device
temp1:        +23.1°C  (crit = +115.0°C)

drivetemp-scsi-0-0
Adapter: SCSI adapter
temp1:        +42.0°C  (low  = +10.0°C, high = +40.0°C)
                       (crit low =  +5.0°C, crit = +60.0°C)
                       (lowest = +26.0°C, highest = +44.0°C)

tcpm_source_psy_8_0022-i2c-8-22
Adapter: rk3x-i2c
in0:           0.00 V  (min =  +0.00 V, max =  +0.00 V)
curr1:         0.00 A  (max =  +0.00 A)

gpu_thermal-virtual-0
Adapter: Virtual device
temp1:        +23.1°C  (crit = +115.0°C)

littlecore_thermal-virtual-0
Adapter: Virtual device
temp1:        +24.1°C  (crit = +115.0°C)

bigcore0_thermal-virtual-0
Adapter: Virtual device
temp1:        +24.1°C  (crit = +115.0°C)
```

</details>

CONFIG_TASK_DELAY_ACCT=y helps some utilities (e.g. iotop, iotop-c) to gather more detailed statistics. One still needs to enable it in runtime via e.g. systemctl, kernel command line or interactively (e.g. iotop-c can do it for you).

Tested with Radxa ROCK 5 ITX