### PR TITLE
feat: linux: support product-specific builds

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -15,7 +15,7 @@ Automatic mode:
 Manual mode:
     $(basename "$0") [options] <linux|u-boot> <profile> [product]
 
-    When building u-boot, you can also provide the 'product' argument,
+    When building linux or u-boot, you can also provide the 'product' argument,
     which will only build for that specific product, instead of for all products
     supported by the specified profile.
 

--- a/lib/linux.sh
+++ b/lib/linux.sh
@@ -71,6 +71,17 @@ bsp_makedeb() {
 }
 
 component_build() {
+    local profile="$1" product="$2"
+    
+    if [[ -n "$product" ]]
+    then
+        if ! in_array "$product" "${SUPPORTED_BOARDS[@]}"
+        then
+            error $EXIT_UNKNOWN_OPTION "$product"
+        fi
+        SUPPORTED_BOARDS=("$product")
+    fi
+    
     if $DTB_ONLY
     then
         BSP_MAKE_TARGETS=("dtbs")


### PR DESCRIPTION
## Summary
This PR adds product-specific build support to the Linux component, making it consistent with the U-Boot component behavior.

## Changes
- **lib/linux.sh**: Modified `component_build()` function to accept and handle the product parameter
- **lib/info.sh**: Updated help documentation to reflect that product selection works for both Linux and U-Boot

## Problem
Previously, when building Linux kernels with a specific board (e.g., `./bsp linux rk2410 rock-5b`), the system would still build packages for ALL boards supported by the profile, not just the specified board.

## Solution
The Linux `component_build()` function now:
1. Accepts the product parameter
2. Validates the product exists in `SUPPORTED_BOARDS`
3. Filters `SUPPORTED_BOARDS` to only include the specified product
4. Only creates packages for the requested board

## Benefits
- **Faster builds**: Only builds packages for the specified board
- **Consistent behavior**: Linux component now matches U-Boot component behavior
- **Reduced package generation**: Avoids creating unnecessary packages for unused boards

## Testing
- [x] Verified that `./bsp linux rk2410 rock-5b` only creates rock-5b packages
- [x] Verified that `./bsp linux rk2410` still creates packages for all boards
- [x] Updated help documentation to reflect the new functionality