### PR TITLE
fix: u-boot: rk2410: rk3399: switch to use RKMINILOADER

### DIFF
--- a/u-boot/rk2410/fork.conf
+++ b/u-boot/rk2410/fork.conf
@@ -236,6 +236,8 @@ bsp_rock-4() {
     local UBUILD_BOARD_VARIANT="$1"
     BSP_DEFCONFIG="${UBUILD_BOARD_VARIANT}-${BSP_SOC}_defconfig"
     RKBIN_DDR="${BSP_SOC}_ddr_800MHz_v"
+    UBOOT_BASE_ADDR=0x200000
+    RKMINILOADER="${BSP_SOC}_miniloader_"
 }
 
 bsp_rock-pi-4a-plus() {


### PR DESCRIPTION
The Rockchip document describes that the rk3399 only supports miniloader. Although it is technically possible to boot the FIT firmware using sd/mmc, but the FIT firmware cannot be booted on spinor flash.

Link: https://vamrs.feishu.cn/sheets/I7u5sedHZhLAV9tzSllcr793nbh?sheet=12cztX&rangeId=12cztX_DLwnD3gqD9&rangeVer=1