### PR TITLE
feat:enable CONFIG_UPROBE_EVENTS and CONFIG_KPROBE_EVENTS to make bpftrace and perf happy

### DIFF
--- a/linux/.common/kconfig.conf
+++ b/linux/.common/kconfig.conf
@@ -879,3 +879,8 @@ CONFIG_SENSORS_DRIVETEMP=m
 #enables some utilities (e.g. iotop, iotop-c) to gather more detailed statistics. One still needs to enable this feature in runtime. CONFIG_TASK_DELAY_ACCT requires CONFIG_TASKSTATS, so it was added explicitly. See https://docs.kernel.org/accounting/delay-accounting.html
 CONFIG_TASK_DELAY_ACCT=y
 CONFIG_TASKSTATS=y
+
+#e.g. perf and bpftrace expect this option enabled to be fully functional
+CONFIG_KPROBE_EVENTS=y
+#perf expects this
+CONFIG_UPROBE_EVENTS=y


### PR DESCRIPTION
Both options are enabled in e.g debian kernel: https://salsa.debian.org/kernel-team/linux/-/blob/debian/latest/debian/config/config?ref_type=heads#L6518-6519