### PR TITLE
fix: u-boot: remove radxa-cm3j-rpi-cm4-io configuration on rk2410

### DIFF
--- a/u-boot/rk2410/fork.conf
+++ b/u-boot/rk2410/fork.conf
@@ -42,7 +42,7 @@ SUPPORTED_BOARDS=(
     #"radxa-cm3-io"
     "radxa-cm3-rpi-cm4-io"
     #"radxa-cm3i-io"
-    "radxa-cm3j-rpi-cm4-io"
+    #"radxa-cm3j-rpi-cm4-io"
     "radxa-e25"
     "radxa-zero3"
 )


### PR DESCRIPTION
Radxa CM3J Raspberry pi CM4 IO board is expected to use the u-boot-rk2601 package after this PR is merged[0].

[0]: https://github.com/radxa-pkg/u-boot-rk2601/pull/17